### PR TITLE
Fix bug #1729

### DIFF
--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -215,7 +215,7 @@ class Event {
 
 		if ( wp_doing_ajax() ) {
 
-			$url = $_SERVER['HTTP_REFERER'];
+			$url = wp_get_raw_referer();
 
 		} else {
 


### PR DESCRIPTION
Switch to using `wp_get_raw_referer()` instead of `$_SERVER['HTTP_REFERER']`. `wp_get_raw_referer()` was introduced in [WordPress 4.5.0](https://developer.wordpress.org/reference/functions/wp_get_raw_referer/) and it also accomodates AJAX calls that utilize the `wp_referer_field` functionality (which has been around since [2.0.4](https://developer.wordpress.org/reference/functions/wp_referer_field/))

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

_Replace this with a good description of your changes & reasoning._

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
